### PR TITLE
fix: add DefinedError reference in RestClientBuilder

### DIFF
--- a/src/lib/primitives/restclient/builder.ts
+++ b/src/lib/primitives/restclient/builder.ts
@@ -157,6 +157,7 @@ export class EitherHelper extends Node {
                 targetPath: ({ _sourcePath: sourcePath }) => sourcePath,
                 definition: (_: Node, { reference }) => {
                     const IncomingHttpHeaders = reference(httpSymbols.IncomingHttpHeaders())
+                    const DefinedError = reference(ajvSymbols.DefinedError())
 
                     return (
                         createWriter()
@@ -170,7 +171,7 @@ export class EitherHelper extends Node {
                     statusCode: StatusCode
                     status: Status<StatusCode>
                     headers: Headers
-                    validationErrors: DefinedError[] | undefined
+                    validationErrors: ${DefinedError}[] | undefined
                     left: T
                     where: Where
                 }`)
@@ -570,7 +571,7 @@ export class RestClientBuilder {
             }
 
             if (this.hasValidateRequestBody) {
-                writer.writeLine(this.writeValidateRequestBody())
+                writer.writeLine(this.writeValidateRequestBody(reference))
             }
 
             if (this.hasAwaitResponse) {
@@ -641,13 +642,14 @@ export class RestClientBuilder {
             .toString()
     }
 
-    private writeValidateRequestBody() {
+    private writeValidateRequestBody(reference: (node: Node) => string) {
         const writer = createWriter()
         if (this.options.useEither) {
+            const DefinedError = reference(ajvSymbols.DefinedError())
             return writer
                 .newLine()
                 .writeLine(
-                    'public validateRequestBody<Parser extends { parse: (o: unknown) => { left: DefinedError[] } | { right: Body } }, Body>(',
+                    `public validateRequestBody<Parser extends { parse: (o: unknown) => { left: ${DefinedError}[] } | { right: Body } }, Body>(`,
                 )
                 .writeLine('parser: Parser, body: unknown )')
                 .block(() => {


### PR DESCRIPTION
This pull request updates the `RestClientBuilder` class to improve type safety and error handling. The changes include:

1. Added a reference to `DefinedError` from Ajv symbols in the `EitherHelper` class.
2. Updated the `Left` interface to use the referenced `DefinedError` type for `validationErrors`.
3. Modified the `writeValidateRequestBody` method to accept a `reference` parameter, allowing for proper type referencing.
4. Updated the `validateRequestBody` method signature to use the referenced `DefinedError` type in its generic constraint.

These changes enhance the type safety of the REST client, particularly when dealing with validation errors and request body parsing.