### PR TITLE
fix: improve handling of mixed type schemas and nullable fields

### DIFF
--- a/src/lib/visitor/arbitrary/arbitrary.ts
+++ b/src/lib/visitor/arbitrary/arbitrary.ts
@@ -125,9 +125,11 @@ export const arbitraryVisitor: ThereforeVisitor<Arbitrary<unknown>, ArbitraryCon
         if (options.regex !== undefined) {
             return regexArbitrary(options.regex)
         }
+        const min = minLength ?? options.minLength
+        const max = maxLength ?? options.maxLength
         return string({
-            minLength: minLength ?? options.minLength,
-            maxLength: maxLength ?? options.maxLength,
+            minLength: min === undefined || max === undefined ? min : Math.min(min, max),
+            maxLength: min === undefined || max === undefined ? max : Math.max(min, max),
             ...restArbitrary,
         })
     },


### PR DESCRIPTION
Enhances type handling in JSON schemas by:
- Properly distributing type-specific fields when splitting mixed types
- Fixing nullable field handling in OpenAPI3 and draft-07 formats
- Adding schema type checking helper functions
- Ensuring min/max length constraints are properly ordered
- Preserving type-specific properties during schema normalization